### PR TITLE
Fix URL

### DIFF
--- a/storcli.xml
+++ b/storcli.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Containers>
-    <PluginURL>hhttps://raw.githubusercontent.com/dkaser/unraid-storcli/main/plugin/storcli.plg</PluginURL>
+    <PluginURL>https://raw.githubusercontent.com/dkaser/unraid-storcli/main/plugin/storcli.plg</PluginURL>
     <PluginAuthor>Derek Kaser</PluginAuthor>
     <Beta>False</Beta>
     <Category>Tools:</Category>


### PR DESCRIPTION
Due to typo, feed automatically aborts since the plugin does technically exist